### PR TITLE
Use float64x2 for _mm_stream_pd temporal store

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -5989,7 +5989,7 @@ FORCE_INLINE void _mm_storeu_si32(void *p, __m128i a)
 FORCE_INLINE void _mm_stream_pd(double *p, __m128d a)
 {
 #if __has_builtin(__builtin_nontemporal_store)
-    __builtin_nontemporal_store(a, (float32x4_t *) p);
+    __builtin_nontemporal_store(a, (float64x2_t *) p);
 #elif defined(__aarch64__)
     vst1q_f64(p, vreinterpretq_f64_m128d(a));
 #else


### PR DESCRIPTION
Replace previously used float32x4 which leads to compilation error when
using clang++.

Fixes: #1 