### PR TITLE
Add cast to compile on ARMv7

### DIFF
--- a/neon_mathfun.h
+++ b/neon_mathfun.h
@@ -319,7 +319,7 @@ static inline v4sf log_ps(v4sf x)
 // FMA version
 static inline v4sf exp_ps(v4sf x)
 {
-    v4sf tmp, fx;
+    v4sf fx;
 
     x = vminq_f32(x, *(v4sf *) _ps_exp_hi);
     x = vmaxq_f32(x, *(v4sf *) _ps_exp_lo);

--- a/neon_mathfun.h
+++ b/neon_mathfun.h
@@ -456,6 +456,4 @@ static inline v4sf sqrt_ps(v4sf val)
 #endif
 }
 
-#pragma GCC diagnostic pop
-
 #endif  // INC_SIMD_NEON_MATHFUN_H_

--- a/simd_utils_sse_strings.h
+++ b/simd_utils_sse_strings.h
@@ -17,7 +17,7 @@
 #include <math.h>
 #include <string.h>
 
-size_t strnlen_s_128(const char *s, size_t maxlen) {
+static inline size_t strnlen_s_128(const char *s, size_t maxlen) {
     if (s == NULL)
         return 0;
 

--- a/sse2neon_wrapper.h
+++ b/sse2neon_wrapper.h
@@ -234,7 +234,7 @@ FORCE_INLINE __m128i _mm_cvtpd_epi64(__m128d a)
 #else
     int64_t a0 = (int64_t) ((double *) &a)[0];
     int64_t a1 = (int64_t) ((double *) &a)[1];
-    return _mm_set_epi64(a1, a0);
+    return _mm_set_epi64((__m64)a1, (__m64)a0);
 #endif
 }
 


### PR DESCRIPTION
When compiling on Android to ARMv7 `__m64` is `int64x1_t`, so this doesn't compile without a cast